### PR TITLE
Update Other Uses page

### DIFF
--- a/other-uses.md
+++ b/other-uses.md
@@ -4,28 +4,28 @@ title: Other Uses
 permalink: /other-uses/
 ---
 
-We’ve focused on tiles, but since OpenStreetMap – uniquely – gives you access to the raw map data, you can build any location or geo- application. These are the most common starting points.
+We’ve focused on tiles, but since OpenStreetMap – uniquely – gives you access to the raw map data, you can build any location or geo- application. These are the most common starting points; a full listing is available [at the OpenStreetMap Wiki](http://wiki.openstreetmap.org/wiki/Frameworks).
 
 ## Common tools
 * [Osmosis](http://wiki.openstreetmap.org/wiki/Osmosis) is an all-purpose Java application for loading OSM data into a database. Most applications of OSM data use Osmosis in some way.
 * [Osmium](http://wiki.openstreetmap.org/wiki/Osmium) is a flexible framework, rapidly gaining popularity, which offers a highly configurable alternative to Osmosis.
+* [Mapbox Studio](https://www.mapbox.com/mapbox-studio/) is a suite of tools to produce ‘vector tiles’ which can be rendered either server-side or client-side.
 
-## Geocoding
+## Geocoding services
 * [Nominatim](http://wiki.openstreetmap.org/wiki/Nominatim) is OpenStreetMap’s geocoding service (placename<->lat/long). It has significant hardware requirements and many people choose to use the free instance offered by [MapQuest Open](http://open.mapquestapi.com/nominatim/).
 * [OpenCage](http://geocoder.opencagedata.com/) provides a public geocoding API aggregating Nominatim and other sources.
 
-## Routing
+## Routing engines and services
 * [OSRM](http://project-osrm.org/) is a new, fast routing engine designed for OSM data.
 * [Gosmore](http://sourceforge.net/projects/gosmore/) is a long-established routing engine.
 * [Graphhopper](http://graphhopper.com/) is a fast Java routing engine.
 * Public routing APIs using OSM data are offered by [MapQuest Open](http://open.mapquestapi.com/directions/) and [Mapbox](https://www.mapbox.com/directions/).
 * Specialist routing APIs include [CycleStreets cycle routing](http://www.cyclestreets.net/api/) (UK)
 
-## Mobile libraries
+## Vector map libraries (mobile)
 * Android libraries include the [Mapbox Android SDK](https://www.mapbox.com/android-sdk/), [mapsforge](http://mapsforge.org/), [Nutiteq Maps SDK](https://developer.nutiteq.com/), [Skobbler Android SDK](http://developer.skobbler.com/), and [Tangram ES](https://github.com/tangrams/tangram-es/).
 * iOS libraries include the [Mapbox iOS SDK](https://www.mapbox.com/ios-sdk/), [Nutiteq Maps SDK](https://developer.nutiteq.com/), [Skobbler iOS SDK](http://developer.skobbler.com/), and [Tangram ES](https://github.com/tangrams/tangram-es/).
 
-## Vector rendering
+## Vector map libraries (Web)
 * [Kothic JS](https://github.com/kothic/kothic-js) renders OSM data “on the fly” using HTML5, without the need for raster tile images.
 * [Mapbox GL JS](https://www.mapbox.com/mapbox-gl-js/) and [Tangram](http://tangrams.github.io/tangram/) render vector tiles based on OSM data using WebGL for better performance.
-* [Mapbox Studio](https://www.mapbox.com/mapbox-studio/) is a suite of tools to produce ‘vector tiles’ which can be rendered either server-side or client-side.

--- a/other-uses.md
+++ b/other-uses.md
@@ -18,12 +18,11 @@ We’ve focused on tiles, but since OpenStreetMap – uniquely – gives you acc
 * [OSRM](http://project-osrm.org/) is a new, fast routing engine designed for OSM data.
 * [Gosmore](http://sourceforge.net/projects/gosmore/) is a long-established routing engine.
 * [Graphhopper](http://graphhopper.com/) is a fast Java routing engine.
-* Public routing APIs using OSM data are offered by [MapQuest Open](http://developer.mapquest.com/web/products/open/directions-service) and [CloudMade](http://developers.cloudmade.com/projects/show/routing-http-api).
+* Public routing APIs using OSM data are offered by [MapQuest Open](http://open.mapquestapi.com/directions/).
 * Specialist routing APIs include [CycleStreets cycle routing](http://www.cyclestreets.net/api/) (UK)
 
 ## Mobile libraries
-* iPhone/iOS libraries include [Route-Me](https://github.com/route-me/route-me) and [CloudMade’s SDK](http://cloudmade.com/products/iphone-sdk).
-* Android libraries include [osmdroid](http://code.google.com/p/osmdroid/).
+* Android libraries include [osmdroid](http://osmdroid.org/).
 
 ## Vector rendering
 * [Kothic-JS](https://github.com/kothic/kothic-js) is an in-development new technology which renders OSM data “on the fly” using HTML5, without the need for raster tile images.

--- a/other-uses.md
+++ b/other-uses.md
@@ -18,12 +18,14 @@ We’ve focused on tiles, but since OpenStreetMap – uniquely – gives you acc
 * [OSRM](http://project-osrm.org/) is a new, fast routing engine designed for OSM data.
 * [Gosmore](http://sourceforge.net/projects/gosmore/) is a long-established routing engine.
 * [Graphhopper](http://graphhopper.com/) is a fast Java routing engine.
-* Public routing APIs using OSM data are offered by [MapQuest Open](http://open.mapquestapi.com/directions/).
+* Public routing APIs using OSM data are offered by [MapQuest Open](http://open.mapquestapi.com/directions/) and [Mapbox](https://www.mapbox.com/directions/).
 * Specialist routing APIs include [CycleStreets cycle routing](http://www.cyclestreets.net/api/) (UK)
 
 ## Mobile libraries
-* Android libraries include [osmdroid](http://osmdroid.org/).
+* Android libraries include the [Mapbox Android SDK](https://www.mapbox.com/android-sdk/), [mapsforge](http://mapsforge.org/), [Nutiteq Maps SDK](https://developer.nutiteq.com/), [Skobbler Android SDK](http://developer.skobbler.com/), and [Tangram ES](https://github.com/tangrams/tangram-es/).
+* iOS libraries include the [Mapbox iOS SDK](https://www.mapbox.com/ios-sdk/), [Nutiteq Maps SDK](https://developer.nutiteq.com/), [Skobbler iOS SDK](http://developer.skobbler.com/), and [Tangram ES](https://github.com/tangrams/tangram-es/).
 
 ## Vector rendering
-* [Kothic-JS](https://github.com/kothic/kothic-js) is an in-development new technology which renders OSM data “on the fly” using HTML5, without the need for raster tile images.
+* [Kothic JS](https://github.com/kothic/kothic-js) renders OSM data “on the fly” using HTML5, without the need for raster tile images.
+* [Mapbox GL JS](https://www.mapbox.com/mapbox-gl-js/) and [Tangram](http://tangrams.github.io/tangram/) render vector tiles based on OSM data using WebGL for better performance.
 * [Mapbox Studio](https://www.mapbox.com/mapbox-studio/) is a suite of tools to produce ‘vector tiles’ which can be rendered either server-side or client-side.


### PR DESCRIPTION
This PR updates the Other Uses page, removing discontinued products, updating links, and adding links to products and projects that’ve sprung up since the page was originally written.

In the interest of fairness, I’ve included links to not only the libraries I work on but also its competitors. In the interest of simplicity, I’ve omitted many map libraries that are less sophisticated (lacking vector map support) or target less common environments (like Windows Phone). That said, there are certainly better ways of organizing this information. [This wiki page](http://wiki.openstreetmap.org/wiki/Frameworks), though complete, must be overwhelming to this site’s readers, but maybe we can strike a balance somehow.