### PR TITLE
Missing trailing slash to solve #39

### DIFF
--- a/serving-tiles/manually-building-a-tile-server-16-04-2-lts.md
+++ b/serving-tiles/manually-building-a-tile-server-16-04-2-lts.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Manually building a tile server (16.04.2 LTS)
-permalink: /serving-tiles/manually-building-a-tile-server-16-04-2-lts
+permalink: /serving-tiles/manually-building-a-tile-server-16-04-2-lts/
 ---
 
 This page describes how to install, setup and configure all the necessary software to operate your own tile server. The step-by-step instructions are written for [Ubuntu Linux](http://www.ubuntu.com/) 16.04.2 LTS (Xenial Xerus).


### PR DESCRIPTION
Other working pages have the trailing slash e.g https://raw.githubusercontent.com/switch2osm/switch2osm.github.io/master/serving-tiles/building-a-tile-server-from-packages.md (amongst the others)

It's a clue from my viewpoint to solve the issue.
From my viewpoint, merge & let's wait and see :)