### PR TITLE
Update in .travis.yml ruby version to 2.3 due to bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.0.0
+  - 2.3.0
 branches:
   only:
     - /^.*$/


### PR DESCRIPTION
Change Ruby version to support bundler and fix CI failing.
Bundler only support Ruby 2.3+ e.g https://docs.travis-ci.com/user/languages/ruby/#bundler-20