### PR TITLE
Fix due to deploy issue with new design

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,9 @@
 title: Switch2OSM
 description: >
   Switch to OpenStreetMap and discover how you can build beautiful maps from the world’s best map data.
-baseurl: "/switch2osm" # the subpath of your site, e.g. /blog
+baseurl: "" # the subpath of your site, e.g. /blog
 copyright: 2013–2019 OpenStreetMap and contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC BY-SA</a>
-url: https://klokantech.github.io/switch2osm
+url: https://switch2osm.github.io/
 github_username: switch2osm
 
 

--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -4,7 +4,7 @@ body {
 	width: 100%;
 	background-color: $body-color;
 	overflow-x: hidden;
-	background-image: url(/switch2osm/assets/img/body-bg.png);
+	background-image: url(/assets/img/body-bg.png);
 	background-size: 1600px auto;
 	background-repeat: no-repeat;
 }


### PR DESCRIPTION
With merge of #60, the site has been broken due to hosting difference e.g https://klokantech.github.io/switch2osm/ (so with a subpath) vs http://switch2osm.github.io/ (no subpath)
This PR fixes the issue.