### PR TITLE
Bundler fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,4 +246,4 @@ DEPENDENCIES
   github-pages
 
 BUNDLED WITH
-   2.0.2
+   1.17.3

--- a/_config.yml
+++ b/_config.yml
@@ -6,9 +6,14 @@ copyright: 2013–2019 OpenStreetMap and contributors, <a href="http://creativec
 url: https://switch2osm.github.io
 github_username: switch2osm
 
-
 # Build settings
 markdown: kramdown
+
+# Repo files to not include in built site
+exclude:
+  - Dockerfile*
+  - docker-compose.*
+  - Gemfile
 
 menu:
   - title: Why Switch?


### PR DESCRIPTION
Workaround:
https://bundler.io/blog/2019/05/14/solutions-for-cant-find-gem-bundler-with-executable-bundle.html

And exclude some files from build.