### PR TITLE
Add override config for when building for switch2osm.org

### DIFF
--- a/_config_osm.yml
+++ b/_config_osm.yml
@@ -1,0 +1,3 @@
+# Addon to _config.yml used when generating for https://switch2osm.org
+# eg: --config _config.yml,_config_osm.yml
+url: https://switch2osm.org


### PR DESCRIPTION
Add a config file to use for overriding the `site.url`