### PR TITLE
replace dead link for metro extracts

### DIFF
--- a/serving-tiles/index.md
+++ b/serving-tiles/index.md
@@ -26,7 +26,7 @@ Serving your own maps is a fairly intensive task. Depending on the size of the a
 We would recommend that you begin with extracts of OpenStreetMap data – for example, a city, county or small country – rather than spending a week importing the whole world (planet.osm) and then having to restart because of a configuration mistake! You can download extracts from:
 
 * [Geofabrik](http://download.geofabrik.de/osm/) (countries and provinces)
-* [Metro extracts](http://metro.teczno.com/) (city areas)
+* [Protomaps Extracts](https://protomaps.com/extracts/) (minutely-updated cities and small countries)
 
 # The toolchain
 


### PR DESCRIPTION
Link to protomaps.com/extracts as another extract source.

http://metro.teczno.com/ has been a dead link for a few years now. I'm running a free minutely-updated on-demand extracts service now that I can provide as an alternative. 

With regards to the README guidelines:

> Does not require specific external services, aside from OpenStreetMap itself
> 
> We do not promote anything which can result in lock-in to a specific vendor, so guides need to be usable without relying on a third party. It's okay to use something as an example (e.g. tile.osm.org) where there are plenty of alternatives, but not if there are few alternatives or the service being used cannot be reproduced.

I think that this service should be okay, given that there are plenty of alternatives and it is self-hostable (includes links to the open source backend in the footer)