### PR TITLE
remove OpenCage from development services and consulting list

### DIFF
--- a/other-uses.md
+++ b/other-uses.md
@@ -14,7 +14,7 @@ We’ve focused on tiles, but since OpenStreetMap – uniquely – gives you acc
 ## Geocoding services
 * [Gisgraphy](https://www.gisgraphy.com) is an open source geocoder that provides API / webservices for forward and reverse geocoding with auto-completion, interpolation, location Bias, find nearby, all can be run offline or as hosted solutions. It provide some importers for Openstreetmap but also Openadresses, Geonames, and more.
 * [Nominatim](http://wiki.openstreetmap.org/wiki/Nominatim) is OpenStreetMap’s geocoding service (placename<->lat/long). It has significant hardware requirements and many people choose to use the free instance offered by [MapQuest Open](http://open.mapquestapi.com/nominatim/).
-* [OpenCage](http://geocoder.opencagedata.com/) provides a public geocoding API aggregating Nominatim and other sources.
+* [OpenCage](https://opencagedata.com/) provides a geocoding API aggregating Nominatim and other open sources.
 * [OSMNames](https://osmnames.org/) - place names from OpenStreetMap. Downloadable. Ranked. With bbox and hierarchy. Ready for geocoding.
 
 ## Routing engines and services

--- a/providers.md
+++ b/providers.md
@@ -17,7 +17,6 @@ The following companies offer development services and consulting for sites wish
 * [Mapbox](https://www.mapbox.com/), US
 * [MapTiler](https://www.maptiler.com/), Switzerland
 * [Makina Corpus](https://makina-corpus.com/), France
-* [OpenCage Data](https://opencagedata.com/), UK
 * [Skobbler](https://developer.skobbler.com/), Germany
 * [Stamen](https://stamen.com/), US
 * [Système D](https://www.systemed.net/openstreetmap/ "OpenStreetMap consultancy by Richard Fairhurst"), UK


### PR DESCRIPTION
OpenCage started as consultancy but now does geocoding SaaS exclusively. 

I'm not sure if Mapbox still counts as consultancy, I'd count https://developmentseed.org/ though. 