### PR TITLE
Fix inconsistent capitalisation in menu

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,7 @@ menu:
     url: /the-basics/
   - title: Using Tiles
     url: /using-tiles/
-  - title: Serving tiles
+  - title: Serving Tiles
     url: /serving-tiles/
   - title: Other Uses
     url: /other-uses/


### PR DESCRIPTION
Not a fan of Americanised capitalisation personally, but at least let's make this consistent.