### PR TITLE
Add thunderforest.com to tile providers

### DIFF
--- a/providers.md
+++ b/providers.md
@@ -34,6 +34,7 @@ The following companies host OpenStreetMap tiles.
 * [Nextzen](https://www.nextzen.org/), US
 * [Skobbler](https://developer.skobbler.com/), Germany
 * [Stamen](https://stamen.com/), US
+* [Thunderforest](https://www.thunderforest.com), UK
 
 ### Paid customers only
 


### PR DESCRIPTION
I was kinda surprised to *not* see @gravitystorm's thunderforest (of opencyclemap hosting fame) in the list of providers for the revamped switch2osm... so there.

There's a free tier (detailed in https://www.thunderforest.com/pricing/), so I'm adding the link in the "allows free usage" section.