### PR TITLE
Update link for Nominatim and remove MapQuest

### DIFF
--- a/other-uses.md
+++ b/other-uses.md
@@ -13,7 +13,7 @@ We’ve focused on tiles, but since OpenStreetMap – uniquely – gives you acc
 
 ## Geocoding services
 * [Gisgraphy](https://www.gisgraphy.com) is an open source geocoder that provides API / webservices for forward and reverse geocoding with auto-completion, interpolation, location Bias, find nearby, all can be run offline or as hosted solutions. It provide some importers for Openstreetmap but also Openadresses, Geonames, and more.
-* [Nominatim](http://wiki.openstreetmap.org/wiki/Nominatim) is OpenStreetMap’s geocoding service (placename<->lat/long). It has significant hardware requirements and many people choose to use the free instance offered by [MapQuest Open](http://open.mapquestapi.com/nominatim/).
+* [Nominatim](https://nominatim.org) is the software behind OpenStreetMap’s geocoding service (placename<->lat/long).
 * [OpenCage](https://opencagedata.com/) provides a geocoding API aggregating Nominatim and other open sources.
 * [OSMNames](https://osmnames.org/) - place names from OpenStreetMap. Downloadable. Ranked. With bbox and hierarchy. Ready for geocoding.
 


### PR DESCRIPTION
MapQuest is not really available anymore (at least not for  free). For Nominatim, change primary URL to nominatim.org.