### PR TITLE
Fixing typo in one of links to old packaged instructions.

### DIFF
--- a/serving-tiles/index.md
+++ b/serving-tiles/index.md
@@ -17,7 +17,7 @@ If you are setting up your own tile server, we recommend that you use [Ubuntu Li
 # The options
 
 1. [Build a tile server from source](manually-building-a-tile-server-18-04-lts/)
-2. [Build a tile server using packages](ubuntu-14-building-a-tile-server-from-packages/)
+2. [Build a tile server using packages](building-a-tile-server-from-packages/)
 
 # System requirements
 Serving your own maps is a fairly intensive task. Depending on the size of the area you’re interested in serving and the traffic you expect the system requirements will vary. In general, requirements will range from 10-20GB of storage, 4GB of memory, and a modern dual-core processor for a city-sized region to 300GB+ of fast storage, 24GB of memory, and a quad-core processor for the entire planet.


### PR DESCRIPTION
Should resolve https://github.com/switch2osm/switch2osm.github.io/issues/98 once merged.