### PR TITLE
Fix tile usage policy link

### DIFF
--- a/the-basics/index.md
+++ b/the-basics/index.md
@@ -17,7 +17,7 @@ To switch to OpenStreetMap, you’ll need to replace both of these.
 ![Tiles](tiles.png)
 The map tiles, images of (usually) 256 x 256 pixels each, are drawn (“rendered”) from a map database.
 
-If you currently use Google Maps, you’ll be using Google’s map tiles, hosted at google.com. Because the OpenStreetMap Foundation is a non-profit organisation with limited resources, you can’t just slot in the tiles from openstreetmap.org as a replacement (see the [Tile Usage Policy](https://wiki.openstreetmap.org/wiki/Tile_usage_policy)). Instead, you can:
+If you currently use Google Maps, you’ll be using Google’s map tiles, hosted at google.com. Because the OpenStreetMap Foundation is a non-profit organisation with limited resources, you can’t just slot in the tiles from openstreetmap.org as a replacement (see the [Tile Usage Policy](https://operations.osmfoundation.org/policies/tiles/)). Instead, you can:
 
 * Generate your own tiles, by downloading the free OSM map database and rendering them;
 


### PR DESCRIPTION
Link direct to the policy at operations.osmfoundation.org, not the old wiki location (which just links onward to there)