### PR TITLE
Add Geoapify as map tile and service provider

### DIFF
--- a/providers.md
+++ b/providers.md
@@ -11,6 +11,7 @@ The following companies offer development services and consulting for sites wish
 * [AND Automotive Navigation Data](https://www.and.com/services-3/map-hosting/), Netherlands
 * [Camptocamp](https://camptocamp.com/), Switzerland
 * [Carto](https://carto.com/), US
+* [Geoapify](https://www.geoapify.com/), Germany
 * [Geofabrik](https://www.geofabrik.de/), Germany
 * [GreenInfo Network](https://www.greeninfo.org/), US (public interest groups only)
 * [ITO!](https://www.itoworld.com/), UK
@@ -30,6 +31,7 @@ The following companies host OpenStreetMap tiles.
 ### Allows free usage
 
 * [Carto](https://carto.com/), US
+* [Geoapify](https://www.geoapify.com/api/map-tiles/), Germany
 * [Jawg](https://www.jawg.io/), France
 * [Mapbox](http://mapbox.com/), US
 * [MapTiler](https://www.maptiler.com/), Switzerland


### PR DESCRIPTION
Could you please kindly mention us as a tile provider? We offer free vector and raster tiles, without any restrictions on commercial use. 
And, thank you for the switch2osm! Great resource. Hope to give more valuable contributions to it one day. 