### PR TITLE
Remove Ito World as a provider

### DIFF
--- a/providers.md
+++ b/providers.md
@@ -14,7 +14,6 @@ The following companies offer development services and consulting for sites wish
 * [Geoapify](https://www.geoapify.com/), Germany
 * [Geofabrik](https://www.geofabrik.de/), Germany
 * [GreenInfo Network](https://www.greeninfo.org/), US (public interest groups only)
-* [ITO!](https://www.itoworld.com/), UK
 * [Jawg](https://www.jawg.io/), France
 * [Mapbox](https://www.mapbox.com/), US
 * [MapTiler](https://www.maptiler.com/), Switzerland


### PR DESCRIPTION
Ito World are no longer (and haven't for several years) providing consulting services for organisations interested in OSM data. We still use OSM data internally and for a few services, however don't want to advertise and attract clients for this as it's not a core part of our business. Linked to #53