### PR TITLE
Updated docker instructions to match latest docker container.

### DIFF
--- a/serving-tiles/using-a-docker-container.md
+++ b/serving-tiles/using-a-docker-container.md
@@ -4,7 +4,7 @@ title: Using a Docker container
 permalink: /serving-tiles/using-a-docker-container/
 ---
 
-If you just want to try things out or you're using an OS other than Ubuntu, and you're using Docker for containerisation, you can try [this](https://github.com/Overv/openstreetmap-tile-server/blob/master/README.md).  It's based on the instructions [here](https://switch2osm.org/serving-tiles/manually-building-a-tile-server-18-04-lts/), but is a pre-built container you can install.
+If you just want to try things out or you're using an OS other than Ubuntu, and you're using Docker for containerisation, you can try [this](https://github.com/Overv/openstreetmap-tile-server/blob/master/README.md) (thanks to all the contributors there).  It's based on the instructions [here](https://switch2osm.org/serving-tiles/manually-building-a-tile-server-18-04-lts/), but is a pre-built container you can install.
 
 # Docker
 
@@ -23,15 +23,15 @@ Create a docker volume for the data:
 
 And install it and import the data:
 
-    time docker run -v /home/renderaccount/zambia-latest.osm.pbf:/data.osm.pbf -v openstreetmap-data:/var/lib/postgresql/10/main overv/openstreetmap-tile-server import
+    time docker run -v /home/renderaccount/zambia-latest.osm.pbf:/data.osm.pbf -v openstreetmap-data:/var/lib/postgresql/12/main overv/openstreetmap-tile-server:1.3.10 import
 
 The path to the data file needs to be the absolute path to the data file - it can't be a relative path.  In this example it's in the root directory of the "renderaccount" user.
 
 How long this takes depends very much on the local network speed and the size of the area that you are loading. Zambia, used in this example, is relatively small.
 
-Note that if something goes wrong the error messages may be somewhat cryptic - you might get “… is a directory” if the data file isn’t found. The “time” at the start of the command isn’t necessary for the installation and import; it just tells you how long it took for future reference.
+Note that if something goes wrong the error messages may be somewhat cryptic - you might get “… is a directory” if the data file isn’t found. The “time” at the start of the command isn’t necessary for the installation and import; it just tells you how long it took for future reference.  Also, the postgres version used by this container changed between versions 1.3.5 and 1.3.6 (see [here](https://github.com/Overv/openstreetmap-tile-server/releases/tag/v1.3.6)).  This means that an "openstreetmap-data" created with an earlier version won't work - you will need to remove it with "docker volume rm openstreetmap-data" and recreate.
 
-For more details about what it’s actually doing, have a look at [this file](https://github.com/Overv/openstreetmap-tile-server/blob/master/Dockerfile). You’ll see that it closely matches the “manually building a tile server” instructions [here](https://switch2osm.org/serving-tiles/manually-building-a-tile-server-18-04-lts/), with some minor changes such as the tile URL and the internal account used. Internally you can see that it’s using Ubuntu 18.04, though you don’t need to interact with that directly.
+For more details about what it’s actually doing, have a look at [this file](https://github.com/Overv/openstreetmap-tile-server/blob/master/Dockerfile). You’ll see that it closely matches the “manually building a tile server” instructions [here](https://switch2osm.org/serving-tiles/manually-building-a-tile-server-18-04-lts/), with some minor changes such as the tile URL and the internal account used. Internally you can see that it’s using Ubuntu 18.04.  You don’t need to interact with that directly, but you can (via "docker exec -it mycontainernumber bash") if you want to).
 
 When the import is complete you should see something like this:
 
@@ -45,13 +45,17 @@ That tells you how long things took in total (in this case 9.5 minutes).
 
 To start the tile server running:
 
-    docker run -p 80:80 -v openstreetmap-data:/var/lib/postgresql/10/main -d overv/openstreetmap-tile-server run
+    docker run -p 80:80 -v openstreetmap-data:/var/lib/postgresql/12/main -d overv/openstreetmap-tile-server:1.3.10 run
 
 and to check that it’s working, browse to:
 
     http://your.server.ip.address/tile/0/0/0.png
 
 You should see a map of the world in your browser.
+
+## More Information
+
+This docker container actually supports a lot more than the simple example here - see the [readme](https://github.com/Overv/openstreetmap-tile-server/blob/master/README.md) for more details about updates, performance tweaks, etc.
 
 ## Viewing tiles
 


### PR DESCRIPTION
Docker container now uses postgres 12.
I've also linked to the version of the docker container (actually 1.3.10) to avoid this being an issue in the future.