### PR TITLE
Fixed typo "bondaries" (boundaries) in each of these files.

### DIFF
--- a/serving-tiles/manually-building-a-tile-server-16-04-2-lts.md
+++ b/serving-tiles/manually-building-a-tile-server-16-04-2-lts.md
@@ -235,7 +235,7 @@ The final argument is the data file to load.
 That command will complete with something like "Osm2pgsql took 238s overall".
 ## Shapefile download
 
-Although most of the data used to create the map is directly from the OpenStreetMap data file that you downloaded above, some shapefiles for things like low-zoom country bondaries are still needed. To download and index these:
+Although most of the data used to create the map is directly from the OpenStreetMap data file that you downloaded above, some shapefiles for things like low-zoom country boundaries are still needed. To download and index these:
 
     cd ~/src/openstreetmap-carto/
     scripts/get-external-data.py

--- a/serving-tiles/manually-building-a-tile-server-18-04-lts.md
+++ b/serving-tiles/manually-building-a-tile-server-18-04-lts.md
@@ -239,7 +239,7 @@ The final argument is the data file to load.
 That command will complete with something like "Osm2pgsql took 238s overall".
 ## Shapefile download
 
-Although most of the data used to create the map is directly from the OpenStreetMap data file that you downloaded above, some shapefiles for things like low-zoom country bondaries are still needed. To download and index these:
+Although most of the data used to create the map is directly from the OpenStreetMap data file that you downloaded above, some shapefiles for things like low-zoom country boundaries are still needed. To download and index these:
 
     cd ~/src/openstreetmap-carto/
     scripts/get-external-data.py

--- a/serving-tiles/manually-building-a-tile-server-20-04-lts.md
+++ b/serving-tiles/manually-building-a-tile-server-20-04-lts.md
@@ -214,7 +214,7 @@ The final argument is the data file to load.
 That command will complete with something like "Osm2pgsql took 238s overall".
 ## Shapefile download
 
-Although most of the data used to create the map is directly from the OpenStreetMap data file that you downloaded above, some shapefiles for things like low-zoom country bondaries are still needed. To download and index these:
+Although most of the data used to create the map is directly from the OpenStreetMap data file that you downloaded above, some shapefiles for things like low-zoom country boundaries are still needed. To download and index these:
 
     cd ~/src/openstreetmap-carto/
     scripts/get-external-data.py


### PR DESCRIPTION
Minor typo in each file; spotted while doing the Debian page.

Currently the upstream problem described at https://github.com/gravitystorm/openstreetmap-carto/issues/4249 applies to each of these pages, but hopefully that will be fixed soon at Natural Earth, and the workaround is documented at OSM Carto.