### PR TITLE
Update updating-as-people-edit.md

### DIFF
--- a/serving-tiles/updating-as-people-edit.md
+++ b/serving-tiles/updating-as-people-edit.md
@@ -38,6 +38,10 @@ Also in there is:
 
 That will need to be changed to whatever is the non-root username below which the "mod_tile" and "regional" source exists.  On Debian 11 it will be different to the account that you are rendering tiles as.  
 
+Something else to consider is that you'll probably want to edit the OSM2PGSQL_OPTIONS to refer to the lua tag transform script that you used when loading the database.  There may be other parameters that you need to pass here too depending on what you used when creating the database.  Change "/path/to/" to the actual path, of course:
+
+     OSM2PGSQL_OPTIONS="-d $DBNAME --tag-transform-script /path/to/src/openstreetmap-carto/openstreetmap-carto.lua"
+     
 Next, we'll create the log directory for tile expiry logs, and change the ownership to the username used for rendering tiles (for Debian 11, this will be "_renderd").  The script must also be run as this account, and because this account may be different to where the software is downloaded, we'll pass the complete location of the script - modify "/path/to" to whatever is correct.
 
 The parameter passed to openstreetmap-tiles-update-expire should be the age of the data originally loaded.  If you downloaded data from Geofabrik it should be what the "and contains all OSM data up" date was on e.g. "http://download.geofabrik.de/asia/azerbaijan.html" when you downloaded the data.


### PR DESCRIPTION
Someone on IRC mentioned that as they'd used different osm2pgsql arguments to the defaults for OSM Carto they'd need to use different ones at update too, which the guide needs to note.

Also, I noticed that no lua file was specified at all.  This "works" (I tested it at the weekend and did see updates coming through) but it'll fall back to the old C transforms so where lua and C differ there may be some odd effects.