### PR TITLE
Added Ubuntu 21 page to the index.

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -17,6 +17,7 @@ layout: default
             <li><a href="{{ site.url }}/serving-tiles/manually-building-a-tile-server-debian-11/">Manually building a tile server (Debian 11)</a></li>
             <li><a href="{{ site.url }}/serving-tiles/manually-building-a-tile-server-20-04-lts/">Manually building a tile server (Ubuntu 20.04 LTS)</a></li>
             <li><a href="{{ site.url }}/serving-tiles/using-a-docker-container/">Using a Docker container</a></li>
+            <li><a href="{{ site.url }}/serving-tiles/manually-building-a-tile-server-ubuntu-21/">Manually building a tile server (Ubuntu 21.04)</a></li>
             <li><a href="{{ site.url }}/serving-tiles/manually-building-a-tile-server-18-04-lts/">Manually building a tile server (Ubuntu 18.04 LTS)</a></li>
             <li><a href="{{ site.url }}/serving-tiles/manually-building-a-tile-server-16-04-2-lts/">Manually building a tile server (Ubuntu 16.04.2 LTS)</a></li>
             <li><a href="{{ site.url }}/serving-tiles/updating-as-people-edit/">Updating your database as people edit OpenStreetMap</a></li>

--- a/serving-tiles/manually-building-a-tile-server-ubuntu-21.md
+++ b/serving-tiles/manually-building-a-tile-server-ubuntu-21.md
@@ -112,7 +112,7 @@ You now have a Mapnik XML stylesheet at /home/youruseraccount/src/openstreetmap-
 
 Initially, we'll load only a small amount of test data. Other download locations are available, but "download.geofabrik.de" has a wide range of options. In this example we'll download the data for Azerbaijan, which is about 17Mb.
 
-Browse to https://download.geofabrik.de/asia/azerbaijan.html and note the "This file was last modified" date (e.g. "2020-11-13T21:42:03Z"). We'll need that later if we want to update the database with people's susbsequent changes to OpenStreetMap. Download it as follows:
+Browse to https://download.geofabrik.de/asia/azerbaijan.html and note the "This file was last modified" date (e.g. "2021-09-16T20:21:14Z"). We'll need that later if we want to update the database with people's susbsequent changes to OpenStreetMap. Download it as follows:
 
     mkdir ~/data
     cd ~/data
@@ -231,7 +231,7 @@ If you look at /var/log/syslog, you should see messages from the "renderd" servi
     
 In syslog you should see a message like:
 
-    Nov 14 14:24:55 servername apachectl[19119]: [Sat Nov 14 14:24:55.526717 2020] [tile:notice] [pid 19119:tid 140525098995008] Loading tile config s2o at /hot/ for zooms 0 - 20 from tile directory /var/lib/mod_tile with extension .png and mime type image/png
+    Sep 18 12:25:14 servername apachectl[42239]: [Sat Sep 18 12:25:14.749940 2021] [tile:notice] [pid 42239:tid 139637396966720] Loading tile config s2o at /hot/ for zooms 0 - 20 from tile directory /var/lib/mod_tile with extension .png and mime type image/png
 
 Next, point a web browser at "http://yourserveripaddress/index.html" (change yourserveripaddress to your actual server address).  You should see "Apache2 Ubuntu Default Page".
 


### PR DESCRIPTION
Added Ubuntu 21 page to the index.
Also a couple of other minor changes to the Ubuntu 21 page - replace some data that was copied from Debian with data referencing "now" rather than "2020".