### PR TITLE
added SmartMaps to providers list

### DIFF
--- a/providers.md
+++ b/providers.md
@@ -22,6 +22,7 @@ The following companies offer development services and consulting for sites wish
 * [MapTiler](https://www.maptiler.com/), Switzerland
 * [Makina Corpus](https://makina-corpus.com/), France
 * [Skobbler](https://developer.skobbler.com/), Germany
+* [SmartMaps by YellowMap](https://www.smartmaps.net/en/), Germany
 * [Stadia Maps](https://stadiamaps.com), US
 * [Stamen](https://www.stamen.com/), US
 * [Système D](https://www.systemeD.net/openstreetmap/ "OpenStreetMap consultancy by Richard Fairhurst"), UK
@@ -39,6 +40,7 @@ The following companies host OpenStreetMap tiles.
 * [MapTiler](https://www.maptiler.com/), Switzerland
 * [Nextzen](https://www.nextzen.org/), US
 * [Skobbler](https://developer.skobbler.com/), Germany
+* [SmartMaps by YellowMap](https://www.smartmaps.net/en/), Germany
 * [Stadia Maps](https://stadiamaps.com), US
 * [Stamen](https://stamen.com/), US
 * [Thunderforest](https://www.thunderforest.com), UK


### PR DESCRIPTION
Hi there.

SmartMaps (formerly known as YellowMaps) was established more than ten years ago and is developed by YellowMap AG which is a Bronze Corporate Member of the OSM foundation.
In addition to a free usage via SmartMaps Free, we also provide assistance and support when switiching to OSM from other map platforms.
It would be great to be added to these lists.

Thank you :)