### PR TITLE
Add the ".style" to "OSM2PGSQL_OPTIONS"

### DIFF
--- a/serving-tiles/updating-as-people-edit.md
+++ b/serving-tiles/updating-as-people-edit.md
@@ -40,9 +40,9 @@ Also in there is:
 
 That will need to be changed to whatever is the non-root username below which the "mod_tile" and "regional" source exists.  On Debian 11 it will be different to the account that you are rendering tiles as.  
 
-Something else to consider is that you'll probably want to edit the OSM2PGSQL_OPTIONS to refer to the lua tag transform script that you used when loading the database.  There may be other parameters that you need to pass here too depending on what you used when creating the database.  Change "/path/to/" to the actual path, of course:
+Something else to consider is that you'll probably want to edit the OSM2PGSQL_OPTIONS to refer to the lua tag transform script that you used when loading the database, and the ".style" file that determines what columns are created.  There may be other parameters that you need to pass here too depending on what you used when creating the database.  Change "/path/to/" to the actual path, of course:
 
-     OSM2PGSQL_OPTIONS="-d $DBNAME --tag-transform-script /path/to/src/openstreetmap-carto/openstreetmap-carto.lua"
+     OSM2PGSQL_OPTIONS="-d $DBNAME --tag-transform-script /path/to/src/openstreetmap-carto/openstreetmap-carto.lua -S /path/to/src/openstreetmap-carto/openstreetmap-carto.style"
      
 Next, we'll create the log directory for tile expiry logs, and change the ownership to the username used for rendering tiles (for Debian 11, this will be "_renderd").  The script must also be run as this account, and because this account may be different to where the software is downloaded, we'll pass the complete location of the script - modify "/path/to" to whatever is correct.
 


### PR DESCRIPTION
"src/openstreetmap-carto/openstreetmap-carto.style" has changed, and "addr:interpolation" is no longer stored for nodes.  This makes logical sense and is a bugfix in openstreetmap-carto, but is different to osm2pgsql's default.  This means that "OSM2PGSQL_OPTIONS" needs to reference the .style file that was used to create the database in the first place (arguably, it always should have done this).

The actual location of the .style file depends on the account that the user used to fetch it, and on Debian it'll always be different to the account that renderd runs under.

https://help.openstreetmap.org/questions/78817/keep-in-sync-local-database-with-osm-latest-changes-to-region is an example of this problem elsewhere.