### PR TITLE
Debian: default mod_tile timeout

### DIFF
--- a/serving-tiles/manually-building-a-tile-server-debian-11.md
+++ b/serving-tiles/manually-building-a-tile-server-debian-11.md
@@ -254,4 +254,6 @@ Edit so that the IP address matches yourserveraddress rather than just saying "1
 
 The initial map display will take a little while.  You'll be able to zoom in and out, but depending on server speed some tiles may initially display as grey because they can't be rendered in time for the browser.  However, once done they’ll be ready for the next time that they are needed.  If you look in /var/log/syslog you should see requests for tiles. 
 
+If desired, you can increase the setting "ModTileMissingRequestTimeout" in "/etc/apache2/conf-available/renderd.conf" from 10 seconds to perhaps 30 or 60, in order to wait longer for tiles to be rendered in the background before a grey tile is given to the user.  Make sure you "sudo service renderd restart" and "sudo service apache2 restart" after changing it.
+
 Congratulations. Head over to the [using tiles](https://switch2osm.github.io/using-tiles/) section to create a map that uses your new tile server.


### PR DESCRIPTION
Historically, ModTileMissingRequestTimeout was set to 30.  The version packaged into Debian now has 10 (as well has offering more customisations).

I've updated manually-building-a-tile-server-debian-11.md to suggest increasing 10 to 30 as "target market" users of this guide will likely at least initially have a slower server that might need longer to render tiles.  

A lower number will make perfect sense to some people, but I think the default suggested in this guide should be higher.
Note that "the first time that people view tiles" they won't have pre-rendered anything, so will be waiting for their first tile at zoom <= 12 (something unlikely to happen in normal operation).