### PR TITLE
Update manually-building-a-tile-server-18-04-lts.md

### DIFF
--- a/serving-tiles/manually-building-a-tile-server-18-04-lts.md
+++ b/serving-tiles/manually-building-a-tile-server-18-04-lts.md
@@ -14,6 +14,12 @@ It consists of 5 main components: mod_tile, renderd, mapnik, osm2pgsql and a pos
 
 Note that these instructions are have been written and tested against a newly-installed Ubuntu 18.04 server. If you have got other versions of some software already installed (perhaps you upgraded from an earlier Ubuntu version, or you set up some PPAs to load from) then you may need to make some adjustments.
 
+This guide assumes that you run everything from a non-root user via “sudo”. The non-root username used by default below is “renderaccount” - you can create that locally if you want, or edit scripts to refer to a different username if you want. If you do create the “renderaccount” user you’ll need to add it to the group of users that can sudo to root. From your normal non-root user account:
+
+    sudo -i
+    usermod -aG sudo renderaccount
+    exit
+
 In order to build these components, a variety of dependencies need to be installed first:
 
     sudo add-apt-repository multiverse


### PR DESCRIPTION
Added "use a non-root account" again (from https://switch2osm.org/serving-tiles/manually-building-a-tile-server-20-04-lts/ ).  Prompted by https://help.openstreetmap.org/questions/82750/2-issues-to-do-with-root-user-stopping-my-first-tile-server-from-working-renderd-atj-external-datapy .