### PR TITLE
Clear ".running" files at renderd startup

### DIFF
--- a/serving-tiles/updating-as-people-edit-osm2pgsql-replication.md
+++ b/serving-tiles/updating-as-people-edit-osm2pgsql-replication.md
@@ -209,7 +209,7 @@ The script to perform the update can be edited as above to output a summary to a
 
 As we're updating based on minutely updates, and we've made the script check that it is not already running before trying to apply updates, we can run this more often than once per day; in this case every 5 minutes.
 
-It's a good idea to clear the "pyosmium is running" flag when renderd is restated.  To do that:
+It's a good idea to clear the "osm2pgsql-replication is running" flag when renderd is restated.  To do that:
 
     sudo nano /usr/lib/systemd/system/renderd.service
 

--- a/serving-tiles/updating-as-people-edit-osm2pgsql-replication.md
+++ b/serving-tiles/updating-as-people-edit-osm2pgsql-replication.md
@@ -208,3 +208,16 @@ The script to perform the update can be edited as above to output a summary to a
     */5 *  *   *   *     sudo -u _renderd /usr/local/sbin/update_tiles.sh >> /var/log/tiles/run.log
 
 As we're updating based on minutely updates, and we've made the script check that it is not already running before trying to apply updates, we can run this more often than once per day; in this case every 5 minutes.
+
+It's a good idea to clear the "pyosmium is running" flag when renderd is restated.  To do that:
+
+    sudo nano /usr/lib/systemd/system/renderd.service
+
+and add:
+
+    ExecStartPre=rm /var/cache/renderd/update_tiles.sh.running
+
+in the "[Service]" section.  Then:
+
+    sudo systemctl daemon-reload
+    sudo systemctl restart renderd

--- a/serving-tiles/updating-as-people-edit-pyosmium.md
+++ b/serving-tiles/updating-as-people-edit-pyosmium.md
@@ -108,3 +108,16 @@ and then add:
     */5 *  *   *   *     /usr/local/sbin/call_pyosmium.sh >> /var/log/tiles/run.log
 
 The script checks that it is not already running before trying to apply updates, so can run it fairly frequently; in this case every 5 minutes.
+
+It's a good idea to clear the "pyosmium is running" flag when renderd is restated.  To do that:
+
+    sudo nano /usr/lib/systemd/system/renderd.service
+
+and add:
+
+    ExecStartPre=rm /var/cache/renderd/pyosmium/call_pyosmium.running
+
+in the "[Service]" section.  Then:
+
+    sudo systemctl daemon-reload
+    sudo systemctl restart renderd


### PR DESCRIPTION
Clear either /var/cache/renderd/update_tiles.sh.running or /var/cache/renderd/pyosmium/call_pyosmium.running at renderd startup so that neither cron job incorrectly things it is still running.