### PR TITLE
Update updating-as-people-edit-pyosmium.md

### DIFF
--- a/serving-tiles/updating-as-people-edit-pyosmium.md
+++ b/serving-tiles/updating-as-people-edit-pyosmium.md
@@ -115,7 +115,7 @@ It's a good idea to clear the "pyosmium is running" flag when renderd is restate
 
 and add:
 
-    ExecStartPre=rm /var/cache/renderd/pyosmium/call_pyosmium.running
+    ExecStartPre=rm -f /var/cache/renderd/pyosmium/call_pyosmium.running
 
 in the "[Service]" section.  Then:
 


### PR DESCRIPTION
The "ExecStartPre" needs to "rm -f" rather than "rm" to avoid an error preventing the startup.